### PR TITLE
Dat 7 make base template for the agent

### DIFF
--- a/client/agent/.gitignore
+++ b/client/agent/.gitignore
@@ -1,0 +1,30 @@
+# Visual Studio-specific ignores
+.vs/
+*.user
+*.suo
+*.cache
+*.ncb
+*.opendb
+*.VC.db
+*.VC.opendb
+*.pdb
+*.vcxproj.Filters
+
+# Minifilter-specific ignores
+*.sys
+*.inf
+*.cat
+*.cab
+*.sig
+
+# Build output directories
+x64/
+Debug/
+Release/
+build/
+
+# Logs, and temp files
+*.log
+*.tlog
+*.tmp
+

--- a/client/agent/README.md
+++ b/client/agent/README.md
@@ -1,0 +1,1 @@
+MiniFilter Windows kernel driver


### PR DESCRIPTION
This base template only includes:
1. Client and agent directories
2. .gitignore file for the agent - mainly include common VS related files and more specific windows kernel driver files.
3. Simple README