### PR TITLE
DAT-23-expose-alerts-to-the-agent

### DIFF
--- a/frontend/src/pages/AlertsPage.jsx
+++ b/frontend/src/pages/AlertsPage.jsx
@@ -1,0 +1,103 @@
+import { useState, useEffect } from 'react';
+import { FaExclamationCircle, FaExclamationTriangle, FaInfoCircle } from 'react-icons/fa';
+import "../styles/AlertsPage.css";
+
+function AlertsPage({ userId }) {
+    const [alerts, setAlerts] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!userId) {
+            setTimeout(() => {
+                setAlerts([ //mock examples need to DELETE
+                    {
+                        severity: 3,
+                        action: 'DELETE',
+                        file: { filename: 'report2025.docx' },
+                        message: 'This file was permanently removed by admin.',
+                        createdAt: new Date().toISOString()
+                    },
+                    {
+                        severity: 2,
+                        action: 'EDIT',
+                        file: { filename: 'presentation.pptx' },
+                        message: 'File content was modified.',
+                        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString()
+                    },
+                    {
+                        severity: 1,
+                        action: 'UPLOAD',
+                        file: { filename: 'invoice.pdf' },
+                        message: 'Upload completed successfully.',
+                        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString()
+                    }
+                ]);
+                setLoading(false);
+            }, 500);
+            return;
+        }
+
+        fetch(`http://localhost:3000/alerts?userId=${userId}&resource=file`)
+            .then(res => res.ok ? res.json() : [])
+            .then(data =>
+                setAlerts(
+                    data.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+                )
+            )
+            .catch(() => setAlerts([]))
+            .finally(() => setLoading(false));
+    }, [userId]);
+
+    const getIcon = (severity) => {
+        if (severity === 3) return <FaExclamationCircle size={24} color="#c0392b" />;
+        if (severity === 2) return <FaExclamationTriangle size={24} color="#e67e22" />;
+        return <FaInfoCircle size={24} color="#2980b9" />;
+    };
+
+    const formatTimestamp = (ts) => {
+        const date = new Date(ts);
+        if (isNaN(date)) return "Invalid date";
+        return date.toLocaleString('en-GB', {
+            weekday: 'short',
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+    };
+
+    const formatAction = (action) => {
+        if (!action) return '';
+        return action.charAt(0).toUpperCase() + action.slice(1).toLowerCase();
+    };
+
+    if (!userId && alerts.length === 0 && !loading) {
+        return <div className="alerts-empty">No mock alerts to display.</div>;
+    }
+
+    if (loading) {
+        return <div className="alerts-loading">Loading alerts...</div>;
+    }
+
+    return (
+        <div className="alerts-container">
+            {alerts.map((alert, index) => (
+                <div key={index} className="alert-card">
+                    <div className="alert-icon">{getIcon(alert.severity)}</div>
+                    <div className="alert-content">
+                        <div className="alert-message">
+                            {formatAction(alert.action)} on <strong>{alert.file?.filename || 'Unnamed file'}</strong>
+                        </div>
+                        {alert.message && (
+                            <div className="alert-subtext">{alert.message}</div>
+                        )}
+                        <div className="alert-time">{formatTimestamp(alert.createdAt)}</div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default AlertsPage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cybersecurity-FinalProject",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
       PGADMIN_DEFAULT_PASSWORD: strong-password
     volumes:
       - pgadmin-data:/var/lib/pgadmin
+    networks:
+      - datavault-network
 
 
 networks:

--- a/server/src/main/java/datavault/server/Repository/AlertRepository.java
+++ b/server/src/main/java/datavault/server/Repository/AlertRepository.java
@@ -12,6 +12,7 @@ public interface AlertRepository extends JpaRepository<AlertEntity, Long> {
 
     List<AlertEntity> findBySeverity(Integer severity);
     List<AlertEntity> findByUser_Username(String username);
+    List<AlertEntity> findByUser_UserId(Long userId);
 
     List<AlertEntity> findByAction(String action);
 }

--- a/server/src/main/java/datavault/server/Repository/AlertRepository.java
+++ b/server/src/main/java/datavault/server/Repository/AlertRepository.java
@@ -11,4 +11,7 @@ public interface AlertRepository extends JpaRepository<AlertEntity, Long> {
     List<AlertEntity> findByFile(FileEntity file);
 
     List<AlertEntity> findBySeverity(Integer severity);
+    List<AlertEntity> findByUser_Username(String username);
+
+    List<AlertEntity> findByAction(String action);
 }

--- a/server/src/main/java/datavault/server/controllers/AlertController.java
+++ b/server/src/main/java/datavault/server/controllers/AlertController.java
@@ -22,6 +22,11 @@ public class AlertController {
     public List<AlertEntity> getAlertsByUsername(@PathVariable String username) {
         return alertService.getAlertsByUsername(username);
     }
+    @GetMapping("/user/id/{userId}")
+    public List<AlertEntity> getAlertsByUserId(@PathVariable Long userId) {
+        return alertService.getAlertsByUserId(userId);
+    }
+
 
     @GetMapping("/action/{action}")
     public List<AlertEntity> getAlertsByAction(@PathVariable String action) {

--- a/server/src/main/java/datavault/server/controllers/AlertController.java
+++ b/server/src/main/java/datavault/server/controllers/AlertController.java
@@ -1,0 +1,38 @@
+package datavault.server.controllers;
+
+import datavault.server.entities.AlertEntity;
+import datavault.server.services.AlertService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/alerts")
+public class AlertController {
+
+    @Autowired
+    private AlertService alertService;
+
+    @GetMapping//api/alerts
+    public List<AlertEntity> getAllAlerts() {     // Expose Alerts to Agent
+        return alertService.getAllAlerts();
+    }
+    @GetMapping("/user/{username}")
+    public List<AlertEntity> getAlertsByUsername(@PathVariable String username) {
+        return alertService.getAlertsByUsername(username);
+    }
+
+    @GetMapping("/action/{action}")
+    public List<AlertEntity> getAlertsByAction(@PathVariable String action) {
+        return alertService.getAlertsByAction(action);
+    }
+    @GetMapping("/severity/{severity}")
+    public List<AlertEntity> getAlertsBySeverity(@PathVariable Integer severity) {
+        return alertService.getAlertsBySeverity(severity);
+    }
+    @GetMapping("/file/{fileId}")
+    public List<AlertEntity> getAlertsByFile(@PathVariable Long fileId) {
+        return alertService.getAlertsByFile(fileId);
+    }
+}

--- a/server/src/main/java/datavault/server/controllers/AlertController.java
+++ b/server/src/main/java/datavault/server/controllers/AlertController.java
@@ -15,7 +15,7 @@ public class AlertController {
     private AlertService alertService;
 
     @GetMapping//api/alerts
-    public List<AlertEntity> getAllAlerts() {     // Expose Alerts to Agent
+    public List<AlertEntity> getAllAlerts() {
         return alertService.getAllAlerts();
     }
     @GetMapping("/user/{username}")

--- a/server/src/main/java/datavault/server/services/AlertService.java
+++ b/server/src/main/java/datavault/server/services/AlertService.java
@@ -37,6 +37,9 @@ public class AlertService {
     public List<AlertEntity> getAlertsByUsername(String username) {
         return alertRepository.findByUser_Username(username);
     }
+    public List<AlertEntity> getAlertsByUserId(Long userId) {
+        return alertRepository.findByUser_UserId(userId);
+    }
 
     public List<AlertEntity> getAlertsByAction(String action) {
         return alertRepository.findByAction(action);

--- a/server/src/main/java/datavault/server/services/AlertService.java
+++ b/server/src/main/java/datavault/server/services/AlertService.java
@@ -1,6 +1,7 @@
 package datavault.server.services;
 
 import datavault.server.Repository.AlertRepository;
+import datavault.server.Repository.FileRepository;
 import datavault.server.entities.AlertEntity;
 import datavault.server.entities.FileEntity;
 import datavault.server.entities.UserEntity;
@@ -8,10 +9,14 @@ import datavault.server.enums.Action;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class AlertService {
     @Autowired
     AlertRepository alertRepository;
+    @Autowired
+    private FileRepository fileRepository;
 
     public void saveDuplicateFile(FileEntity file, UserEntity user, Action action) {
         AlertEntity alert = new AlertEntity(file, user, action, 3,
@@ -24,5 +29,24 @@ public class AlertService {
         AlertEntity alert = new AlertEntity(file, user, action, 2,
                 "The user violated acl");
         alertRepository.save(alert);
+    }
+
+    public List<AlertEntity> getAllAlerts() {
+        return alertRepository.findAll();
+    }
+    public List<AlertEntity> getAlertsByUsername(String username) {
+        return alertRepository.findByUser_Username(username);
+    }
+
+    public List<AlertEntity> getAlertsByAction(String action) {
+        return alertRepository.findByAction(action);
+    }
+    public List<AlertEntity> getAlertsBySeverity(Integer severity) {
+        return alertRepository.findBySeverity(severity);
+    }
+    public List<AlertEntity> getAlertsByFile(Long fileId) {
+        FileEntity file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new RuntimeException("File not found with id: " + fileId));
+        return alertRepository.findByFile(file);
     }
 }


### PR DESCRIPTION
Implemented an endpoint to expose alerts from the server to the agent. Added support for filtering alerts by user, action, severity, and file. This enables the agent to fetch relevant alerts in real time for monitoring and visibility.

Example requests:
- GET http://localhost:8080/api/alerts – fetch all alerts
- GET http://localhost:8080/api/alerts/user/<username> – filter by username
- GET http://localhost:8080/api/alerts/action/<action> – filter by action (READ, WRITE,...)
- GET http://localhost:8080/api/alerts/severity/<level> – filter by severity (1–3)
- GET http://localhost:8080/api/alerts/file/<fileId> – filter by specific file ID

